### PR TITLE
Improve docs and spell checker tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,16 @@ Follow these rules when making changes.
 ## Testing
 - Run `dotnet test` from `/` whenever backend code or libraries change.
 
+## Project Structure
+- `API/` contains the ASP.NET Core web API (`CoretorOrtografic.API`).
+- `Apps/` hosts command line applications, e.g. `CoretorOrtografic.CLI`.
+- `Libraries/` holds the main libraries:
+  - `CoretorOrtografic.Core` with the phonetic algorithm, data entities and abstractions.
+  - `CoretorOrtografic.Infrastructure` with the spell checker implementation and DI module.
+  - `CoretorOrtografic.Dictionaries` with constants and utilities for dictionary data.
+- `Utilities/` provides helper console tools to deploy dictionaries or migrate databases.
+- `Tests/` contains the NUnit test suite.
+
 ## Coding Style
 - **C#** files use 4 spaces for indentation.
 - Write comments and documentation in English.

--- a/Tests/CoretorOrtografic.Tests/Infrastructure/SpellChecker/FurlanSpellCheckerFixture.cs
+++ b/Tests/CoretorOrtografic.Tests/Infrastructure/SpellChecker/FurlanSpellCheckerFixture.cs
@@ -78,5 +78,61 @@ namespace CoretorOrtografic.Tests.Infrastructure.SpellChecker
                 Assert.That(!suggestions.Any());
             }
         }
+
+        [Test]
+        public async Task CheckWord_WordWithDigits_ReturnsTrue()
+        {
+            using (var scope = Container.BeginLifetimeScope())
+            {
+                var spellChecker = scope.Resolve<ISpellChecker>();
+
+                var word = new ProcessedWord("abc123");
+                bool result = await spellChecker.CheckWord(word);
+
+                Assert.That(result);
+            }
+        }
+
+        [Test]
+        public async Task CheckWord_WordStartingWithLApostrophe_ReturnsTrue()
+        {
+            using (var scope = Container.BeginLifetimeScope())
+            {
+                var spellChecker = scope.Resolve<ISpellChecker>();
+
+                var word = new ProcessedWord("l'cjape");
+                bool result = await spellChecker.CheckWord(word);
+
+                Assert.That(result);
+            }
+        }
+
+        [Test]
+        public void ExecuteSpellCheck_ShortWordsAreMarkedCorrect()
+        {
+            using (var scope = Container.BeginLifetimeScope())
+            {
+                var spellChecker = scope.Resolve<ISpellChecker>();
+
+                spellChecker.ExecuteSpellCheck("ai cjape");
+                var firstWord = spellChecker.ProcessedWords.First() as ProcessedWord;
+
+                Assert.That(firstWord.Correct);
+            }
+        }
+
+        [Test]
+        public async Task GetWordSuggestions_HyphenatedWord_ReturnsCombinedSuggestion()
+        {
+            using (var scope = Container.BeginLifetimeScope())
+            {
+                var spellChecker = scope.Resolve<ISpellChecker>();
+
+                var word = new ProcessedWord("cjupe-cjase");
+                var suggestions = await spellChecker.GetWordSuggestions(word);
+
+                Assert.That(suggestions, Does.Contain("cjape cjase"));
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- explain project layout in AGENTS instructions
- add extra FurlanSpellChecker edge case tests

## Testing
- `dotnet test -c Release-Codex`

------
https://chatgpt.com/codex/tasks/task_e_686e1e3b4b908330967a783ee403ac2a